### PR TITLE
International IBAN input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- Form validates IBAN length based on coutry code
+- Form validates correct pattern for some country codes
+
+### Changed
+- Form input for IBAN no longer assumes country code DE
+- PDF template no longer assumes country code DE
+
 ## v1.5 - 2024-12-10
 
 ### Added

--- a/app/aktive.py
+++ b/app/aktive.py
@@ -525,7 +525,7 @@ class HTMLPrinter:
                      (lambda obj: obj.cost, True),
                      (lambda obj: obj.total, False))
     _PAYMENT_FIELDS = (None,None,None,
-                       lambda obj: obj.iban, lambda obj: obj.accountname)
+                       lambda obj: obj.iban or 'DE', lambda obj: obj.accountname)
     _PAYMENT_BOXES = (lambda obj: obj.ibanmode == 1,
                       lambda obj: obj.ibanmode==1 and obj.ibanknown==True,
                       lambda obj: obj.ibanmode==1 and obj.ibanknown==False,

--- a/app/aktive.py
+++ b/app/aktive.py
@@ -166,7 +166,7 @@ class Abrechnung:
     """
     
     # Class constants
-    _IBANSPACES = range(18,0,-4)
+    _IBANSPACES = range(32,0,-4)
     _MODES_IBAN = (1,2,3)
     _MODES_SEPA = (2,3)
     _NAME = "Aktivenabrechnung"
@@ -404,10 +404,11 @@ class Abrechnung:
     def getaccountiban(self,spaces:bool = True) -> str:
         """Gibt die IBAN des Bankkontos zurück."""
         out = self._payment["iban"]
-        if spaces and len(out) > self._IBANSPACES[0]:
+        if spaces:
             # add spaces
             for i in self._IBANSPACES:
-                out = out[:i] + " " + out[i:]
+                if len(out) > i:
+                    out = out[:i] + " " + out[i:]
         return out
 
     def setibanmode(self,mode=None):

--- a/app/aktive.py
+++ b/app/aktive.py
@@ -393,13 +393,12 @@ class Abrechnung:
     def setaccountiban(self,value=""):
         """
         Legt die IBAN des Bankkontos fest.
-        Diese muss aus exakt 20 Ziffern bestehen (kein Ländercode).
+        Entfernt dabei alle Zeichen außer Buchstaben und Ziffern.
         """
-        value = str(value).replace(" ","")
-        if len(value) == 20 and value.isdigit():
-            self._payment["iban"] = str(value)
-        else:
-            self._payment["iban"] = ""
+        value = sub('[\W_]+', '',value.upper())
+        if len(value) > 34:
+            value = value[:34]
+        self._payment["iban"] = str(value)
     
     def getaccountiban(self,spaces:bool = True) -> str:
         """Gibt die IBAN des Bankkontos zurück."""

--- a/app/aktive.py
+++ b/app/aktive.py
@@ -395,7 +395,7 @@ class Abrechnung:
         Legt die IBAN des Bankkontos fest.
         Entfernt dabei alle Zeichen außer Buchstaben und Ziffern.
         """
-        value = sub('[\W_]+', '',value.upper())
+        value = sub('[\\W_]+', '',value.upper())
         if len(value) > 34:
             value = value[:34]
         self._payment["iban"] = str(value)

--- a/static/js/form_aktive.js
+++ b/static/js/form_aktive.js
@@ -1,6 +1,7 @@
 const moneyform = new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' }); // wird genutzt, um Geldbeträge zu formatieren
 const maxPos = 7; // Maximale Anzahl an Positionen im HTML-Dokument
 const ibanLength = [['NO'],['BE'],[],['DK','FK','FO','FI','GL','NL','SD'],['MK','SI'],['AT','BA','EE','KZ','XK','LT','LU','MN'],['HR','LV','LI','CH'],['BH','BG','CR','GE','DE','IE','ME','RS','GB','VA'],['TL','GI','IQ','IL','OM','SO','AE'],['AD','CZ','MD','PK','RO','SA','SK','ES','SE','TN','VG'],['LY','PT','ST'],['IS','TR'],['BI','DJ','FR','GR','IT','MR','MC','SM'],['AL','AZ','BY','CY','DO','SV','GT','HU','LB','NI','PL'],['BR','EG','PS','QA','UA'],['JO','KW','MU','YE'],['MT','SC'],['LC'],['RU']];
+const ibanNoLetters = ['AE','AT','BA','BE','BI','CR','CZ','DE','DJ','DK','EE','EG','ES','FI','FO','GL','HR','HU','IL','IS','LT','LY','ME','MN','MR','NO','PL','PT','RS','SD','SE','SI','SK','SO','ST','TL','TN','VA','XK'];
 
 var multiplier = [1,1,1,1,1,1,1];
 var multiPosition = [false,false,false,false,false,false,false];
@@ -360,6 +361,9 @@ function validateIban(target) {
 			missing = 'ein';
 		}
 		target.setCustomValidity('Diese IBAN ist '+missing+' Zeichen zu kurz.');
+		} else if (ibanNoLetters.includes(country) && /[A-Z]/.test(target.value.substring(2))) {
+			// Zu viele Buchstaben (sollte nur Ländercode sein)
+			target.setCustomValidity('IBAN mit Ländercode '+country+' dürfen keine weiteren Buchstaben enthalten.');
 	} else {
 			// Berechne Prüfsumme
 			let checksum = target.value.substring(4) + target.value.substring(0,4);

--- a/static/js/form_aktive.js
+++ b/static/js/form_aktive.js
@@ -1,5 +1,7 @@
 const moneyform = new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' }); // wird genutzt, um Geldbeträge zu formatieren
-const maxPos = 7 // Maximale Anzahl an Positionen im HTML-Dokument
+const maxPos = 7; // Maximale Anzahl an Positionen im HTML-Dokument
+const ibanLength = [['NO'],['BE'],[],['DK','FK','FO','FI','GL','NL','SD'],['MK','SI'],['AT','BA','EE','KZ','XK','LT','LU','MN'],['HR','LV','LI','CH'],['BH','BG','CR','GE','DE','IE','ME','RS','GB','VA'],['TL','GI','IQ','IL','OM','SO','AE'],['AD','CZ','MD','PK','RO','SA','SK','ES','SE','TN','VG'],['LY','PT','ST'],['IS','TR'],['BI','DJ','FR','GR','IT','MR','MC','SM'],['AL','AZ','BY','CY','DO','SV','GT','HU','LB','NI','PL'],['BR','EG','PS','QA','UA'],['JO','KW','MU','YE'],['MT','SC'],['LC'],['RU']];
+
 var multiplier = [1,1,1,1,1,1,1];
 var multiPosition = [false,false,false,false,false,false,false];
 var processMem = 0;
@@ -321,30 +323,59 @@ function validateText(target) {
  * @param {HTMLInputElement} target	Das Eingabefeld, das überprüft wird 
  */
 function validateIban(target) {
-	target.value = target.value.toUpperCase().replace(/[^0-9]/g,'');
+	target.value = target.value.toUpperCase().replace(/[^0-9A-Z]/g,'');
 	if (target.validity.valueMissing) {
+		// Eingabe vorrausgesetzt, aber fehlt
 		target.setCustomValidity('Bitte fülle dieses Feld aus.');
-	} else if (target.value.length > 20) {
-		let overflow = target.value.length - 20;
+	} else if ((target.value.length - 1)*(target.value.length - 4) <= 0) {
+		// Länge 1-4
+		target.setCustomValidity('Bitte fülle dieses Feld vollständig aus.');
+	} else if (!(/^[A-Z]{2}[0-9]{2}/.test(target.value))) {
+		// Fängt nicht an mit Buchstabe-Buchstabe-Zahl-Zahl
+		target.setCustomValidity('Bitte schreibe eine IBAN in dieses Feld.');
+	} else {
+
+		const country = target.value.substring(0,2);
+		let minLength = 15;
+		let maxLength = 34;
+		for (let i = 0; i < ibanLength.length; i++) {
+			// Wie lang sollte eine IBAN mit diesem Ländercode sein?
+			if (ibanLength[i].includes(country)) {
+				minLength = i+15;
+				maxLength = i+15;
+				break;
+			}
+		}
+		if (target.value.length > maxLength) {
+			// IBAN zu lang
+			let overflow = target.value.length - maxLength;
 		if (overflow == 1) {
 			overflow = 'ein';
 		}
 		target.setCustomValidity('Diese IBAN ist '+overflow+' Zeichen zu lang.');
-	} else if (target.value.length < 20) {
-		let missing = 20 - target.value.length;
+		} else if (target.value.length < minLength) {
+			// IBAN zu kurz
+			let missing = minLength - target.value.length;
 		if (missing == 1) {
 			missing = 'ein';
 		}
 		target.setCustomValidity('Diese IBAN ist '+missing+' Zeichen zu kurz.');
 	} else {
-		let checksum = target.value.substring(2) + '1314' + target.value.substring(0,2);
+			// Berechne Prüfsumme
+			let checksum = target.value.substring(4) + target.value.substring(0,4);
+			for (let i = 0; i < 26; i++) {
+				checksum = checksum.replaceAll(String.fromCharCode(65+i),(i+10).toString());
+			}
 		while (checksum.length>9) {
 			checksum = checksum.substring(0,9) % 97 + checksum.substring(9);
 		}
 		if (checksum % 97 == 1) {
+				// Alles OK
 			target.setCustomValidity('');
 		} else {
+				// Schlechte Prüfsumme
 			target.setCustomValidity('Dies ist keine gültige IBAN. Überprüfe deine Eingabe bitte auf Fehler.');
+			}
 		}
 	}
 }

--- a/static/js/form_aktive.js
+++ b/static/js/form_aktive.js
@@ -1,7 +1,11 @@
 const moneyform = new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' }); // wird genutzt, um Geldbeträge zu formatieren
 const maxPos = 7; // Maximale Anzahl an Positionen im HTML-Dokument
+
+// Listen von IBAN-Ländercodes mit bestimmten Eigenschaften
 const ibanLength = [['NO'],['BE'],[],['DK','FK','FO','FI','GL','NL','SD'],['MK','SI'],['AT','BA','EE','KZ','XK','LT','LU','MN'],['HR','LV','LI','CH'],['BH','BG','CR','GE','DE','IE','ME','RS','GB','VA'],['TL','GI','IQ','IL','OM','SO','AE'],['AD','CZ','MD','PK','RO','SA','SK','ES','SE','TN','VG'],['LY','PT','ST'],['IS','TR'],['BI','DJ','FR','GR','IT','MR','MC','SM'],['AL','AZ','BY','CY','DO','SV','GT','HU','LB','NI','PL'],['BR','EG','PS','QA','UA'],['JO','KW','MU','YE'],['MT','SC'],['LC'],['RU']];
 const ibanNoLetters = ['AE','AT','BA','BE','BI','CR','CZ','DE','DJ','DK','EE','EG','ES','FI','FO','GL','HR','HU','IL','IS','LT','LY','ME','MN','MR','NO','PL','PT','RS','SD','SE','SI','SK','SO','ST','TL','TN','VA','XK'];
+const iban2Letters = ['FK','GE'];
+const iban4Letters = ['GB','IE','IQ','NI','NL','SV','VG'];
 
 var multiplier = [1,1,1,1,1,1,1];
 var multiPosition = [false,false,false,false,false,false,false];
@@ -363,7 +367,11 @@ function validateIban(target) {
 		target.setCustomValidity('Diese IBAN ist '+missing+' Zeichen zu kurz.');
 		} else if (ibanNoLetters.includes(country) && /[A-Z]/.test(target.value.substring(2))) {
 			// Zu viele Buchstaben (sollte nur Ländercode sein)
-			target.setCustomValidity('IBAN mit Ländercode '+country+' dürfen keine weiteren Buchstaben enthalten.');
+			target.setCustomValidity('IBAN mit Ländercode '+country+' dürfen nach dem Ländercode keine weiteren Buchstaben enthalten.');
+} else if (iban2Letters.includes(country) && (/[0-9]/.test(target.value.substring(4,6)) || /[A-Z]/.test(target.value.substring(6)))) {
+			target.setCustomValidity('IBAN mit Ländercode '+country+' müssen nach Ländercode und Prüfziffer genau zwei Buchstaben enthalten.');
+		} else if (iban4Letters.includes(country) && (/[0-9]/.test(target.value.substring(4,8)) || /[A-Z]/.test(target.value.substring(8)))) {
+			target.setCustomValidity('IBAN mit Ländercode '+country+' müssen nach Ländercode und Prüfziffer genau vier Buchstaben enthalten.');
 	} else {
 			// Berechne Prüfsumme
 			let checksum = target.value.substring(4) + target.value.substring(0,4);

--- a/templates/documents/aktive_template.html
+++ b/templates/documents/aktive_template.html
@@ -124,7 +124,7 @@
 				<td class="check"><!--PLACEHOLDER--></td>
 				<td><table class="subtable"><tr>
 					<td>IBAN:</td>
-					<td>DE<!--PLACEHOLDER--></td>
+					<td><!--PLACEHOLDER--></td>
 					<td>Kontoinhaber:</td>
 					<td><!--PLACEHOLDER--></td>
 				</tr></table></td>

--- a/templates/form_aktive.html
+++ b/templates/form_aktive.html
@@ -181,7 +181,7 @@
 					<label class="option"><input type="radio" id="processtouser" name="prtype" value="1">Wir überweisen den Abrechnungsbetrag auf dein Konto.</label><br>
 				</div>
 				<div class="subinput">
-					<label><abbr title="Internationale Bankkontonummer">IBAN</abbr>: <span class="iban">DE</span><input type="text" name="iban" id="processiban" size=20 class="iban"></label>
+					<label><abbr title="Internationale Bankkontonummer">IBAN</abbr>: <input type="text" name="iban" id="processiban" size=22 placeholder="DE12345678901234567890" class="iban"></label>
 					<label>Kontoinhaber: <input type="text" name="owner" id="processowner" autocomplete="name"></label>
 					<br>
 					<label class="option"><input type="checkbox" name="known" id="processuserknown" value="1">Meine Bankverbindung ist dem ADFC Hamburg bekannt.</label>


### PR DESCRIPTION
Fügt dem Formular (Frontend) teilweise Überprüfung der IBAN-Eingabe hinzu und ermöglicht die Eingabe von IBAN aus anderen Ländern; der Backend-Code wird angepasst, um IBAN mit Ländercode statt ohne Ländercode auszuwerten.

Überprüft werden, dass IBAN mit Ländercode und Prüfziffer anfangen; dass die Prüfziffer stimmt; und dass die IBAN nicht zu lang ist. Für bekannte Ländercodes wird außerdem auf korrekte Länge und (bei manchen) korrekte Platzierung von Buchstaben/Ziffern geprüft.