### PR TITLE
Wechsele Grund-Image zu Linux Alpine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- Underlying Linux image changed from Debian-slim to Alpine
 - Package index update, package installation and index/cache cleaning are combined into a single layer in the docker image
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /abrechnungsformular
 RUN apk update \
  && apk add font-croscore font-dejavu pango \
  && apk cache clean \
- && rm -rf /var/cache/apk/*
+ && rm -rf /var/cache/apk/* /lib/apk/db/*
 
 # Upgrade pip and install Python dependencies
 ENV PIP_ROOT_USER_ACTION=ignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
-# Use the official Python 3.13.0-slim image as base
-FROM python:3.13.0-slim AS base
+# Use the official Python Alpine image as base
+FROM python:3.13.7-alpine3.22 AS base
 
 # Description of resulting image
 LABEL org.opencontainers.image.description="Ein Webserver, über welchen Aktive und Helfer des ADFC Abrechnungsformulare ausfüllen und herunterladen können."
@@ -10,10 +10,10 @@ LABEL org.opencontainers.image.description="Ein Webserver, über welchen Aktive 
 WORKDIR /abrechnungsformular
 
 # Install necessary packages, then delete package index and cache
-RUN apt-get update \
- && apt-get install -y fonts-croscore fonts-dejavu-core libpango1.0-0 \
- && apt-get clean \
- && rm -rf /var/lib/apt/lists/*
+RUN apk update \
+ && apk add font-croscore font-dejavu pango \
+ && apk cache clean \
+ && rm -rf /var/cache/apk/*
 
 # Upgrade pip and install Python dependencies
 ENV PIP_ROOT_USER_ACTION=ignore


### PR DESCRIPTION
Ändert das System, auf dem das Docker-Image Abrechnungsformular aufbaut, von Linux Debian-slim zu Linux Alpine.

Das Image wäre damit in der Zukunft über 130 MB kleiner.