### PR TITLE
Entferne Babel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@
 - Download button for blank PDF form no longer draggable
 - Web forms will no longer (attempt to) load SVG and PNG version of logo at the same time
 
+### Removed
+
+- Python library babel
+
 ## v2.8 - 2026-01-26
 
 ### Changed

--- a/app/aktive.py
+++ b/app/aktive.py
@@ -8,7 +8,6 @@ from decimal import Decimal
 from html import escape
 from re import sub
 
-from babel.dates import format_date
 from drafthorse.models.accounting import ApplicableTradeTax as DH_ApplicableTradeTax
 from drafthorse.models.document import Document as DH_Document
 from drafthorse.models.note import IncludedNote as DH_IncludedNote
@@ -457,7 +456,7 @@ class Abrechnung:
         """
 
         template = tools.pdf_environment.get_template(FILENAMES.AKTIVE_HTML)
-        today = format_date(date.today(),format='long',locale='de_DE')
+        today = tools.format_date(date.today())
 
         return template.render(abrechnung=self,today=today)
 
@@ -481,9 +480,8 @@ class Abrechnung:
         if self.getprojectname():
             note = DH_IncludedNote()
             note.content_code = 'PROJECT'
-            datestring = format_date(self.getprojectdate(),
-                                     format="long",locale="de_DE")
-            note.content = self.getprojectname()+" "+datestring
+            note.content = ' '.join((self.getprojectname(),
+                                    tools.format_date(self.getprojectdate())))
             note.subject_code = "ACD" # Reason
             doc.header.notes.add(note)
 

--- a/app/reise.py
+++ b/app/reise.py
@@ -7,7 +7,7 @@ from datetime import date, datetime, time, timedelta
 from decimal import Decimal
 from re import sub
 
-from babel.dates import format_date, format_time
+from babel.dates import format_date
 from drafthorse.models.accounting import ApplicableTradeTax as DH_ApplicableTradeTax
 from drafthorse.models.document import Document as DH_Document
 from drafthorse.models.note import IncludedNote as DH_IncludedNote
@@ -653,9 +653,9 @@ class Abrechnung():
                 li.settlement.monetary_summation.total_amount = day.getbenefits()
                 note2 = DH_IncludedNote()
                 note2.content_code = 'TIME'
-                note2.content = format_time(self.getbegintime(),
-                    format='short',locale='de_DE')+' - '+format_time(
-                    self.getendtime(),format='short',locale='de_DE')
+                note2.content = ' - '.join((
+                    self.getbegintime().strftime('%H:%M'),
+                    self.getendtime().strftime('%H:%M')))
                 note2.subject_code = "BLO" # Period of time
                 li.document.notes.add(note2)
             else:

--- a/app/reise.py
+++ b/app/reise.py
@@ -7,7 +7,6 @@ from datetime import date, datetime, time, timedelta
 from decimal import Decimal
 from re import sub
 
-from babel.dates import format_date
 from drafthorse.models.accounting import ApplicableTradeTax as DH_ApplicableTradeTax
 from drafthorse.models.document import Document as DH_Document
 from drafthorse.models.note import IncludedNote as DH_IncludedNote
@@ -637,10 +636,9 @@ class Abrechnung():
         for index, day in enumerate(self.days):
             li = tools.TaxExemptLineItem()
             li.document.line_id = 'T'+str(index+1)
-            li.product.name = 'Tagesgeld ' + format_date(
+            li.product.name = 'Tagesgeld ' + tools.format_date(
                 self.getbegindate()+timedelta(days=index),
-                format="EEEE, d. MMMM",locale="de_DE"
-            )
+                with_weekday=True,with_year=False)
             li.agreement.net.basis_quantity = (1,"DAY")
             li.delivery.billed_quantity = (1,"DAY")
             for i, meal in enumerate(day.MEALNAMES):
@@ -748,7 +746,7 @@ class Abrechnung():
         """
 
         template = tools.pdf_environment.get_template(FILENAMES.REISE_HTML)
-        today = format_date(date.today(),format='long',locale='de_DE')
+        today = tools.format_date(date.today())
 
         return template.render(abrechnung=self,today=today,
                                daycount=len(self.days),rates=REISE_RATE,

--- a/app/tools.py
+++ b/app/tools.py
@@ -5,7 +5,6 @@ der Aktivenabrechnung zum Einsatz kommen.
 
 from decimal import Decimal
 
-from babel.dates import format_date
 from drafthorse.models.tradelines import LineItem
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
@@ -53,6 +52,26 @@ def euro(value = 0, empty = False, shorten = False) -> str:
     if shorten:
         out = out.removesuffix(',00')
     return out
+
+def format_date(date,with_weekday:bool=False,with_year:bool=True) -> str:
+    """
+    Gibt ein Datum als String zurück, mit Tag als Zahl (ohne
+    zusätzliche Null) und Monat ausgeschrieben.
+
+    Ist with_weekday True, steht am Anfang der Wochentag ausgeschrieben.
+
+    Ist with_year True, steht am Ende das Jahr mit vier Ziffern.
+    """
+    WEEKDAY_NAMES = ('Montag','Dienstag','Mittwoch','Donnerstag',
+                     'Freitag','Samstag','Sonntag')
+    MONTH_NAMES = ('Januar','Februar','März','April','Mai','Juni','Juli',
+                   'August','September','Oktober','November','Dezember')
+    out = [str(date.day)+'.', MONTH_NAMES[date.month-1]]
+    if with_weekday:
+        out.insert(0,WEEKDAY_NAMES[date.weekday()]+',')
+    if with_year:
+        out.append(str(date.year))
+    return ' '.join(out)
 
 def format_decimal(number, decimals:int = 3, shorten = False) -> str:
     """

--- a/app/tools.py
+++ b/app/tools.py
@@ -5,7 +5,7 @@ der Aktivenabrechnung zum Einsatz kommen.
 
 from decimal import Decimal
 
-from babel.dates import format_date, format_time
+from babel.dates import format_date
 from drafthorse.models.tradelines import LineItem
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
@@ -106,4 +106,4 @@ pdf_environment = Environment(loader=FileSystemLoader(PATHS.PDF_TEMPLATE_FOLDER)
                               autoescape=True)
 pdf_environment.globals.update(address=CONTACT,checkbox=checkbox,euro=euro,
                                format_date=format_date,format_decimal=format_decimal,
-                               format_time=format_time,version=VERSION)
+                               version=VERSION)

--- a/app/tools.py
+++ b/app/tools.py
@@ -5,7 +5,6 @@ der Aktivenabrechnung zum Einsatz kommen.
 
 from decimal import Decimal
 
-from babel.numbers import format_currency, format_decimal
 from babel.dates import format_date, format_time
 from drafthorse.models.tradelines import LineItem
 from jinja2 import Environment, FileSystemLoader, select_autoescape
@@ -50,9 +49,37 @@ def euro(value = 0, empty = False, shorten = False) -> str:
     """
     if empty and not value:
         return ""
-    out = format_currency(value,"EUR",locale="de_DE")
+    out = format_decimal(value,2,False) + u'\N{no-break space}\N{euro sign}'
     if shorten:
-        out = out.replace(',00','')
+        out = out.removesuffix(',00')
+    return out
+
+def format_decimal(number, decimals:int = 3, shorten = False) -> str:
+    """
+    Gibt eine Zahl als String mit Tausendtrennerpunkten und
+    Dezimalkomma zurück.
+
+    decimals legt die Anzahl der Nachkommastellen fest; ist shorten
+    True, werden Nullen am Ende des Bruchteils entfernt.
+    """
+    DECIMAL_SEPARATOR = ','
+    out = format(Decimal(number),f'.{str(decimals)}f').split('.')
+    out[0] = format_digits(out[0])
+    if shorten and len(out) > 1:
+        out[1] = out[1].rstrip('0')
+        if out[1] == '': out.pop(1)
+    return DECIMAL_SEPARATOR.join(out)
+
+def format_digits(number) -> str:
+    """
+    Gibt eine Ganzzahl als String mit Tausendtrennerpunkten zurück.
+    """
+    DIGIT_GROUP_SEPARATOR = '.'
+    DIGIT_GROUP_LENGTH = 3
+    out = format(Decimal(number),'.0f')
+    if len(out) > DIGIT_GROUP_LENGTH:
+        for i in range(len(out)-DIGIT_GROUP_LENGTH,0,-DIGIT_GROUP_LENGTH):
+            out = out[:i] + DIGIT_GROUP_SEPARATOR + out[i:]
     return out
 
 def uppercase_first(text:str) -> str:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ flask>=3.1.0,<3.2.0
 weasyprint>=68.0,<69.0
 #flask_weasyprint>=1.1.0,<1.2.0
 gunicorn>=23.0.0,<24.0.0
-babel>=2.17.0,<2.18.0
 drafthorse>=2025.2.0,<2025.3.0
 schwifty>=2025.9.0,<2025.10.0
 jinja2>=3.1.5,<3.2.0

--- a/templates/documents/aktive_template.html.j2
+++ b/templates/documents/aktive_template.html.j2
@@ -44,7 +44,7 @@
 			</tr>
 			<tr>
 				<td>Datum:</td>
-				<td>{{ format_date(abrechnung.getprojectdate(),format='long',locale='de_DE') if abrechnung else '' }}</td>
+				<td>{{ format_date(abrechnung.getprojectdate()) if abrechnung else '' }}</td>
 			</tr>
 		</table>
 	</div>

--- a/templates/documents/reise_template.html.j2
+++ b/templates/documents/reise_template.html.j2
@@ -51,13 +51,13 @@
 		<tr>
 			<td class="check">{{ checkbox(daycount > 1) | safe }}</td>
 			<td class="label">Mehrtägige Reise</td>
-			<td>Beginn der Reise am:<div class="field date">{% if daycount > 1 %}{{ format_date(abrechnung.begindate,locale='de_DE') }}{% endif %}</div></td>
-			<td>Ende der Reise am:<div class="field date">{% if daycount > 1 %}{{ format_date(abrechnung.enddate,locale='de_DE') }}{% endif %}</div></td>
+			<td>Beginn der Reise am:<div class="field date">{% if daycount > 1 %}{{ abrechnung.begindate.strftime('%d.%m.%Y') }}{% endif %}</div></td>
+			<td>Ende der Reise am:<div class="field date">{% if daycount > 1 %}{{ abrechnung.enddate.strftime('%d.%m.%Y') }}{% endif %}</div></td>
 		</tr>
 		<tr>
 			<td class="check">{{ checkbox(daycount == 1) | safe }}</td>
 			<td class="label">Eintägige Reise</td>
-			<td>Datum der Reise:<div class="field date">{% if daycount == 1 %}{{ format_date(abrechnung.begindate,locale='de_DE') }}{% endif %}</div></td>
+			<td>Datum der Reise:<div class="field date">{% if daycount == 1 %}{{ abrechnung.begindate.strftime('%d.%m.%Y') }}{% endif %}</div></td>
 			<td></td>
 		</tr>
 		<tr>
@@ -144,7 +144,7 @@
 			<tr>
 				<td class="nr">{{ i+1 }}</td>
 				<td class="text{% if abrechnung.positions[i].reason|length > 30 %} shrink-text{% endif %}">{{ abrechnung.positions[i].reason|e }}</td>
-				<td class="date">{% if abrechnung.positions[i].date %}{{ format_date(abrechnung.positions[i].date,locale='de_DE') }}{% endif %}</td>
+				<td class="date">{% if abrechnung.positions[i].date %}{{ abrechnung.positions[i].date.strftime('%d.%m.%Y') }}{% endif %}</td>
 				<td class="money">{{ euro(abrechnung.positions[i].value,empty=True) }}</td>
 				<td></td>
 				<td></td>

--- a/templates/documents/reise_template.html.j2
+++ b/templates/documents/reise_template.html.j2
@@ -63,8 +63,8 @@
 		<tr>
 			<td class="check"></td>
 			<td></td>
-			<td>Beginn der Reise um:<div class="field time">{% if daycount == 1 and abrechnung.begintime %}{{ format_time(abrechnung.begintime,format='short',locale='de_DE') }}{% endif %}</div></td>
-			<td>Ende der Reise um:<div class="field time">{% if daycount == 1 and abrechnung.endtime %}{{ format_time(abrechnung.endtime,format='short',locale='de_DE') }}{% endif %}</div></td>
+			<td>Beginn der Reise um:<div class="field time">{% if daycount == 1 and abrechnung.begintime %}{{ abrechnung.begintime.strftime('%H:%M') }}{% endif %}</div></td>
+			<td>Ende der Reise um:<div class="field time">{% if daycount == 1 and abrechnung.endtime %}{{ abrechnung.endtime.strftime('%H:%M') }}{% endif %}</div></td>
 		</tr>
 	</table>
 

--- a/templates/documents/reise_template.html.j2
+++ b/templates/documents/reise_template.html.j2
@@ -111,7 +111,7 @@
 		<caption>Fahrtkosten</caption>
 		<tr>
 			<td>Im Privat-PKW<br>zurückgelegt:</td>
-			<td class="field"><div class="field km">{% if abrechnung.cardistance %}{{ format_decimal(abrechnung.cardistance,locale="de_DE") }}{% endif %}</div>km</td>
+			<td class="field"><div class="field km">{% if abrechnung.cardistance %}{{ format_decimal(abrechnung.cardistance,shorten=True) }}{% endif %}</div>km</td>
 		</tr>
 	</table>
 


### PR DESCRIPTION
Repliziert die Funktionen des Python-Pakets Babel, die tatsächlich genutzt wurden, und entfernt Babel aus der Liste der zu installierenden Python-Pakete.

Dies reduziert die Größe des Images um knapp 30MB.